### PR TITLE
full multizone support

### DIFF
--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -720,7 +720,7 @@ Map<String, List> deviceSetColorTemperature(com.hubitat.app.DeviceWrapper device
 
 Map<String, List> deviceSetIRLevel(com.hubitat.app.DeviceWrapper device, Number level, Boolean displayed, duration = 0) {
     def actions = makeActions()
-    actions.commands << makeCommand('LIGHT.SET_INFRARED', [irLevel: value == scaleUp100(level)])
+    actions.commands << makeCommand('LIGHT.SET_INFRARED', [irLevel: scaleUp100(level)])
     actions.events << [name: "IRLevel", value: level, displayed: displayed, data: [syncing: "false"]]
     actions
 }

--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -1289,11 +1289,10 @@ private Map getScaledColorMap(Map colorMap) {
     def result = [:]
     def brightness = colorMap.level ?: colorMap.brightness
 
-    colorMap.hue ? result.hue = scaleUp100(colorMap.hue) as Integer : null
-    colorMap.saturation ? result.saturation = scaleUp100(colorMap.saturation) as Integer : null
-    colorMap.saturation ? result.saturation = scaleUp100(colorMap.saturation) as Integer : null
-    brightness ? result.brightness = scaleUp100(brightness) as Integer : null
-    result.kelvin = colorMap.kelvin
+    colorMap.hue instanceof Integer ? result.hue = scaleUp100(colorMap.hue) as Integer : null
+    colorMap.saturation instanceof Integer ? result.saturation = scaleUp100(colorMap.saturation) as Integer : null
+    brightness instanceof Integer ? result.brightness = scaleUp100(brightness) as Integer : null
+    colorMap.kelvin instanceof Integer ? result.kelvin = colorMap.kelvin : null
     result
 }
 
@@ -1359,9 +1358,9 @@ private void clearDeviceDefinitions() {
 }
 
 public Map getDeviceDefinitions() {
-	if (atomicState.devices == null) {
-		atomicState.devices = [:]
-	}
+    if (atomicState.devices == null) {
+        atomicState.devices = [:]
+    }
 
     atomicState.devices
 }

--- a/LIFXMultiZone.groovy
+++ b/LIFXMultiZone.groovy
@@ -114,8 +114,20 @@ def setZones(String colors, duration = 0) {
         //use special index 999 to apply attributes to all zones - overrides any zone-specific inputs
         def indexToApply = colorsMap[999] ? 999 : i
         if (colorsMap[i] != null || colorsMap[999] != null) {
-            def color = parent.getScaledColorMap(colorsMap[indexToApply])
-            theZones.colors[i] = theZones.colors[i] + color
+            String namedColor = colorsMap[indexToApply].color ?: colorsMap[indexToApply].colour
+            Map realColor
+            if (namedColor) {
+                Map myColor
+                myColor = (null == namedColor) ? null : parent.lookupColor(namedColor.replace('_', ' '))
+                realColor = [
+                    hue       : parent.scaleUp(myColor.h ?: 0, 360),
+                    saturation: parent.scaleUp100(myColor.s ?: 0),
+                    brightness: parent.scaleUp100(myColor.v ?: 50)
+                ]
+            } else {
+                realColor = parent.getScaledColorMap(colorsMap[indexToApply])
+            }
+            theZones.colors[i] = theZones.colors[i] + realColor
         }
     }
     theZones['apply'] = 1

--- a/LIFXMultiZoneChild.groovy
+++ b/LIFXMultiZoneChild.groovy
@@ -1,0 +1,150 @@
+/**
+ *
+ *  Copyright 2020 David Kilgore. All Rights Reserved
+ *
+ *  This software is free for Private Use. You may use and modify the software without distributing it.
+ *  If you make a fork, and add new code, then you should create a pull request to add value, there is no
+ *  guarantee that your pull request will be merged.
+ *
+ *  You may not grant a sublicense to modify and distribute this software to third parties without permission
+ *  from the copyright holder
+ *  Software is provided without warranty and your use of it is at your own risk.
+ *
+ */
+
+metadata {
+    definition(name: "LIFX Multizone Child", namespace: "robheyes", author: "David Kilgore", importUrl: 'https://raw.githubusercontent.com/dkilgore90/lifxcode/master/LIFXMultiZoneChild.groovy') {
+        capability 'Light'
+        capability 'ColorControl'
+        capability 'ColorTemperature'
+        capability 'Initialize'
+        capability 'Switch'
+        capability "Switch Level"
+
+        attribute "label", "string"
+        attribute "zone", "number"
+        command "setState", ["MAP"]
+    }
+
+    preferences {
+        input "useActivityLogFlag", "bool", title: "Enable activity logging", required: false
+        input "useDebugActivityLogFlag", "bool", title: "Enable debug logging", required: false
+    }
+}
+
+@SuppressWarnings("unused")
+def installed() {
+    initialize()
+}
+
+@SuppressWarnings("unused")
+def updated() {
+    initialize()
+}
+
+def initialize() {
+    state.useActivityLog = useActivityLogFlag
+    state.useActivityLogDebug = useDebugActivityLogFlag
+    unschedule()
+}
+
+@SuppressWarnings("unused")
+def refresh() {
+
+}
+
+def getZone() {
+    return device.getDataValue("zone")
+}
+
+def on() {
+    parent.setZones(getZone() + ': "[brightness:100]"')
+    device.sendEvent(name: "switch", value: "on")
+    device.sendEvent(name: "level", value: 100)
+}
+
+def off() {
+    parent.setZones(getZone() + ': "[brightness:0]"')
+    device.sendEvent(name: "switch", value: "off")
+    device.sendEvent(name: "level", value: 0)
+}
+
+@SuppressWarnings("unused")
+def setColor(Map colorMap) {
+    parent.setZones(getZone() + ': "[hue: ' + colorMap.hue + ', saturation: ' + colorMap.saturation + ', brightness: '+ colorMap.level + ']"')
+    device.sendEvent(name: "hue", value: colorMap.hue)
+    device.sendEvent(name: "saturation", value: colorMap.saturation)
+    device.sendEvent(name: "level", value: colorMap.level)
+    if (colorMap.level > 0) {
+        device.sendEvent(name: "switch", value: "on")
+    } else if (colorMap.level == 0) {
+        device.sendEvent(name: "switch", value: "off")
+    }
+}
+
+@SuppressWarnings("unused")
+def setHue(hue) {
+    parent.setZones(getZone() + ': "[hue: ' + hue + ']"')
+    device.sendEvent(name: "hue", value: hue)
+}
+
+@SuppressWarnings("unused")
+def setSaturation(saturation) {
+    parent.setZones(getZone() + ': "[saturation: ' + saturation + ']"')
+    device.sendEvent(name: "saturation", value: saturation)
+}
+
+@SuppressWarnings("unused")
+def setColorTemperature(temperature) {
+    parent.setZones(getZone() + ': "[saturation: 0, kelvin: ' + temperature + ']"')
+    device.sendEvent(name: "colorTemperature", value: temperature)
+    device.sendEvent(name: "saturation", value: 0)
+}
+
+@SuppressWarnings("unused")
+def setLevel(level, duration = 0) {
+    parent.setZones(getZone() + ': "[brightness: ' + level + ']"', duration)
+    device.sendEvent(name: "level", value: level)
+}
+
+def getUseActivityLog() {
+    if (state.useActivityLog == null) {
+        state.useActivityLog = true
+    }
+    return state.useActivityLog
+}
+
+def setUseActivityLog(value) {
+    log.debug("Setting useActivityLog to ${value ? 'true' : 'false'}")
+    state.useActivityLog = value
+}
+
+Boolean getUseActivityLogDebug() {
+    if (state.useActivityLogDebug == null) {
+        state.useActivityLogDebug = false
+    }
+    return state.useActivityLogDebug as Boolean
+}
+
+def setUseActivityLogDebug(value) {
+    log.debug("Setting useActivityLogDebug to ${value ? 'true' : 'false'}")
+    state.useActivityLogDebug = value
+}
+
+void logDebug(msg) {
+    if (getUseActivityLogDebug()) {
+        log.debug msg
+    }
+}
+
+void logInfo(msg) {
+    if (getUseActivityLog()) {
+        log.info msg
+    }
+}
+
+void logWarn(String msg) {
+    if (getUseActivityLog()) {
+        log.warn msg
+    }
+}

--- a/LIFXMultiZoneChild.groovy
+++ b/LIFXMultiZoneChild.groovy
@@ -107,6 +107,10 @@ def setLevel(level, duration = 0) {
     device.sendEvent(name: "level", value: level)
 }
 
+def setState(value, duration = 0) {
+    parent.setZones(getZone() + ': "' + value + '"', duration)
+}
+
 def getUseActivityLog() {
     if (state.useActivityLog == null) {
         state.useActivityLog = true

--- a/LIFXMultiZoneChild.groovy
+++ b/LIFXMultiZoneChild.groovy
@@ -13,7 +13,7 @@
  */
 
 metadata {
-    definition(name: "LIFX Multizone Child", namespace: "robheyes", author: "David Kilgore", importUrl: 'https://raw.githubusercontent.com/dkilgore90/lifxcode/master/LIFXMultiZoneChild.groovy') {
+    definition(name: "LIFX Multizone Child", namespace: "robheyes", author: "David Kilgore", importUrl: 'https://raw.githubusercontent.com/robheyes/lifxcode/master/LIFXMultiZoneChild.groovy') {
         capability 'Light'
         capability 'ColorControl'
         capability 'ColorTemperature'

--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ it checks to see whether the acknowledgement was received. If it wasn't received
 one more time.  The reason for this is that UDP messages are not guaranteed to arrive, so it's pretty much
 a small safety net.  You can expect that this will happen at least when the device is next polled (under a minute).
 
+### Using the Multizone capabilities
+The multizone driver provides a generic `setZones` command.  This accepts an input in the following format:
+```0:"[hue: 30, brightness: 100, saturation: 100, kelvin: 3500]", 1:"[hue: 0, brightness: 100, saturation: 0, kelvin:3500"]```
+an entry can be submitted for each zone you want to update, and can contain any combination of parameters - 
+e.g. if you only want to update hue and saturation, you can specify only those values, and the brighness and kelvin
+values for that zone will remain the same.  Likewise, you can omit any zones that you do not want to update.
+
+An additional capability is the creation of child devices for each zone.  The corresponding child device can be
+updated/set like a typical RGBW bulb, and it will update/set the zone in the parent multizone device.  If the parent
+device is updated directly, it will update its children on the next polling interval (1 min).
+
+NOTES: 
+* After creating the child devices, I've found you have to toggle a few things before they start updating
+the parent properly - e.g. flip the "switch" on, off, and on again.  Will see if this can be addressed in a
+future update.
+* If you are making a global update on the parent MZ device which does not set all attributes, such as 
+`setColorTemperature` - the remaining attributes (brightness being the key one in this case) will be set on
+all zones equivalent to the current zone 0 values.
+
 ## Troubleshooting
 ### Undiscovered devices
 If you find that some devices aren't discovered

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The multizone driver provides a generic `setZones` command.  This accepts an inp
 an entry can be submitted for each zone you want to update, and can contain any combination of parameters - 
 e.g. if you only want to update hue and saturation, you can specify only those values, and the brighness and kelvin
 values for that zone will remain the same.  Likewise, you can omit any zones that you do not want to update.
+As an alternate to specific HBSK values, you can specify any of the defined `namedColors` or an RGB hex value using
+```0:"[color: 'Red']", 1:"[color: '#0000FF']"```
 
 An additional capability is the creation of child devices for each zone.  The corresponding child device can be
 updated/set like a typical RGBW bulb, and it will update/set the zone in the parent multizone device.  If the parent


### PR DESCRIPTION
# CHANGELOG

## LIFXMasterApp
* Fix deviceSetIRLevel (same change as PR #81)
* update getScaledColorMap so that specified 0 values are not dropped

## LIFXMultiZone
* new command setZones - allows user to specify a zone/hsbk map list to set unique values to specific zones
* add support for setHue, setSaturation, setLevel
* support optional child devices per zone - create/delete using new commands createChildDevices and deleteChildDevices

## LIFXMultiZoneChild
* new driver for child devices per zone - provides general RGBW support on a per-zone basis