### PR TITLE
MZ Fixes

### DIFF
--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -679,9 +679,15 @@ Map<String, List> deviceOnOff(String value, Boolean displayed, duration = 0) {
     actions
 }
 
-Map<String, List> deviceSetZones(com.hubitat.app.DeviceWrapper device, Map zoneMap, Boolean displayed = true) {
+Map<String, List> deviceSetZones(com.hubitat.app.DeviceWrapper device, Map zoneMap, Boolean displayed = true, String power = 'on') {
     def actions = makeActions()
     actions.commands << makeCommand('MULTIZONE.SET_EXTENDED_COLOR_ZONES', zoneMap)
+    
+    if (null != power && device.currentSwitch != power) {
+        def powerLevel = 'on' == power ? 65535 : 0
+        actions.commands << makeCommand('LIGHT.SET_POWER', [powerLevel: powerLevel, duration: duration * 1000])
+        actions.events << [name: "switch", value: power, displayed: displayed, data: [syncing: "false"]]
+    }
     actions
 }
 

--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -685,7 +685,7 @@ Map<String, List> deviceSetZones(com.hubitat.app.DeviceWrapper device, Map zoneM
     
     if (null != power && device.currentSwitch != power) {
         def powerLevel = 'on' == power ? 65535 : 0
-        actions.commands << makeCommand('LIGHT.SET_POWER', [powerLevel: powerLevel, duration: duration * 1000])
+        actions.commands << makeCommand('LIGHT.SET_POWER', [powerLevel: powerLevel, duration: zoneMap.duration * 1000])
         actions.events << [name: "switch", value: power, displayed: displayed, data: [syncing: "false"]]
     }
     actions

--- a/LIFXMultiZone.groovy
+++ b/LIFXMultiZone.groovy
@@ -136,6 +136,10 @@ def setZones(String colors, duration = 0) {
     theZones['apply'] = 1
     theZones['duration'] = duration
     sendActions parent.deviceSetZones(device, theZones)
+    
+    //immediately update locally cached multizone states
+    updateChildDevices(theZones)
+    state.lastMultizone = theZones
 }
 
 @SuppressWarnings("unused")
@@ -154,6 +158,10 @@ def zonesLoad(String name, duration = 0) {
     theZones['duration'] = duration * 1000
     logDebug "Sending $theZones"
     sendActions parent.deviceSetZones(device, theZones)
+    
+    //immediately update locally cached multizone states
+    updateChildDevices(theZones)
+    state.lastMultizone = theZones
 }
 
 def zonesDelete(String name) {

--- a/LIFXMultiZone.groovy
+++ b/LIFXMultiZone.groovy
@@ -226,7 +226,11 @@ def setColorTemperature(temperature) {
 
 @SuppressWarnings("unused")
 def setLevel(level, duration = 0) {
-    setZones('999:"[brightness: ' + level + ']"', duration)
+    if ((null == level || level <= 0) && 0 == duration) {
+        off()
+    } else {
+        setZones('999:"[brightness: ' + level + ']"', duration)
+    }
 }
 
 @SuppressWarnings("unused")


### PR DESCRIPTION
# CHANGELOG

* Power on when setting zone attributes
* Power off when setLevel <= 0
* Update child devices, lastMultizone when sending zone changes - this prevents multiple updates within a single polling window from overwriting the previous.