### PR TITLE
Non-multizone support for Candle Color

### DIFF
--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -1858,17 +1858,17 @@ private Map deviceVersion(Map device) {
             ]
         case 57:
         case 68:
-			return [
-					name      : 'LIFX Candle',
-					deviceName: 'LIFX Color',
-					features  : [
-							color            : true,
-							infrared         : false,
-							multizone        : false,
-							temperature_range: [min: 2500, max: 9000],
-							chain            : false
-					]
-			]
+            return [
+                    name      : 'LIFX Candle',
+                    deviceName: 'LIFX Color',
+                    features  : [
+                            color            : true,
+                            infrared         : false,
+                            multizone        : false,
+                            temperature_range: [min: 1500, max: 9000],
+                            chain            : false
+                    ]
+            ]
         default:
             return [name: "Unknown LIFX device with product id ${device.product}"]
     }

--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -1856,6 +1856,19 @@ private Map deviceVersion(Map device) {
                             chain            : false
                     ]
             ]
+        case 57:
+        case 68:
+			return [
+					name      : 'LIFX Candle',
+					deviceName: 'LIFX Color',
+					features  : [
+							color            : true,
+							infrared         : false,
+							multizone        : false,
+							temperature_range: [min: 2500, max: 9000],
+							chain            : false
+					]
+			]
         default:
             return [name: "Unknown LIFX device with product id ${device.product}"]
     }


### PR DESCRIPTION
Non-multizone support for candle color bulbs.  Uses the existing LIFX Color driver to support basic functionality.