### PR TITLE
Add support for LIFX Mini A60 E27

### DIFF
--- a/LIFXMasterApp.groovy
+++ b/LIFXMasterApp.groovy
@@ -1773,6 +1773,7 @@ private Map deviceVersion(Map device) {
             ]
         case 51:
         case 61:
+        case 66:
             return [
                     name      : 'LIFX Mini White',
                     deviceName: 'LIFX White Mono',


### PR DESCRIPTION
Prior to this change I was seeing the following error in the logs

```
app:332021-01-16 19:40:31.492 warnDevice type 'null' in namespace 'robheyes' not found - you need to install the appropriate driver
```

After adding `logInfo device.inspect()` into `makeRealDevice` I saw that my LIFX Mini has a different product ID:

```
app:332021-01-16 19:40:31.487 info['ip':'192.168.1.145', 'name':'Unknown LIFX device with product id 66', 'location':'Home', 'label':'Sofa Lamp', 'mac':'*********', 'group':'Living Room']
```